### PR TITLE
fix: README.mdの誤りを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ python -m auth.auth
 
 ## 監視デーモンプロセスを起動する場合  
 ```python
-from get_mail import Monitoring, start
+from get_mail import Monitoring, start_daemon
 
 monitoring = Monitoring('search_word_for_subject', 'file_save_destination', 60) # 60 is check interval(sec.)
-start(monitoring)
+start_daemon(monitoring)
 ```
 
 ## 即時実行のみ行う場合


### PR DESCRIPTION
監視デーモンプロセスを起動する場合の、ファンクション名が誤っていたので修正
(誤: start → 正 start_daemon)